### PR TITLE
fix(pr): remove section specific to a repo, move things around

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,8 +2,7 @@
 
 ## Description
 
-<!-- Describe your solution for the issue here. Adding videos, screenshots and expected logs may help the others to understand what is new.
--->
+<!-- Describe what your PR does here, change log, etc -->
 
 ## Related Issues
 <!--
@@ -12,9 +11,8 @@ For example:
 
 Closes #12345
 Unblocks #54321
--->
-
 This PR solves #12345
+-->
 
 ## Progress
 
@@ -25,15 +23,15 @@ This PR solves #12345
 - [ ] Create tests;
 -->
 
+<!-- Also, don't forget to review your code before marking it as ready to merge -->
+
 ### Pull request checklist
 
 <!-- Before submitting the PR, please address each item -->
 
 - [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
 - [ ] **Docs**: This PR updates/creates the necessary documentation.
-- [ ] **Commits descriptions**: All commits in this PR contain a title and description according to [CONTRIBUTING.md](https://github.com/profusion/quickstart-nodejs-rest/blob/master/doc/CONTRIBUTING.md#commits).
-
-<!-- Also, don't forget to review your code before marking it as ready to merge -->
+- [ ] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)
 
 ## How to test it
 
@@ -50,15 +48,4 @@ For example: if this is a bug fix, provide before and after screenshots
 Before | After
 :-:|:-:
 <img width="350" alt="Screenshot of screen pre bug fix" src="your-image-url-here"> | <img width="350" alt="Screenshot of screen post bug fix" src="your-image-url-here">
--->
-
-## Change logs
-
-<!--
-Change logs are important to keep trace of what was changed and make it easier to recover from bugs. You can create a bullet list containing a concise description of what was introduced by your PR, such as:
-
-- Features added or modified
-- Bugs fixed
-- Components removed
-- Chore tasks added/updated
 -->


### PR DESCRIPTION
## Description

- Remove `Change Log` section, which was overkill since we already have a `Description` section
- Remove mention of visual references from `Description`, since we have a dedicated section for that
- Move things to where they should be
- Remove `commit description` from checklist. Some commits don't need a message, and the link
was broken anyway since it always pointed to the rest repo
- Add CI step to checklist